### PR TITLE
[PROMP-99] Allow for local syncing of all pieces

### DIFF
--- a/packages/server/api/src/app/pieces/piece-sync-service.ts
+++ b/packages/server/api/src/app/pieces/piece-sync-service.ts
@@ -1,5 +1,5 @@
 import { PieceMetadataModel, PieceMetadataModelSummary } from '@activepieces/pieces-framework'
-import { AppSystemProp, apVersionUtil } from '@activepieces/server-shared'
+import { AppSystemProp, apVersionUtil, filePiecesUtils } from '@activepieces/server-shared'
 import { ListVersionsResponse, PackageType, PieceSyncMode, PieceType } from '@activepieces/shared'
 import dayjs from 'dayjs'
 import { FastifyBaseLogger } from 'fastify'
@@ -19,7 +19,7 @@ const syncMode = system.get<PieceSyncMode>(AppSystemProp.PIECES_SYNC_MODE)
 
 export const pieceSyncService = (log: FastifyBaseLogger) => ({
     async setup(): Promise<void> {
-        if (syncMode !== PieceSyncMode.OFFICIAL_AUTO) {
+        if (syncMode === PieceSyncMode.NONE) {
             log.info('Piece sync service is disabled')
             return
         }
@@ -39,10 +39,16 @@ export const pieceSyncService = (log: FastifyBaseLogger) => ({
         })
     },
     async sync(): Promise<void> {
-        if (syncMode !== PieceSyncMode.OFFICIAL_AUTO) {
+        if (syncMode === PieceSyncMode.NONE) {
             log.info('Piece sync service is disabled')
             return
         }
+
+        if (syncMode === PieceSyncMode.LOCAL) {
+            await pieceSyncService(log).syncLocal()
+            return
+        }
+
         try {
             log.info({ time: dayjs().toISOString() }, 'Syncing pieces')
             const pieces = await listPieces()
@@ -60,6 +66,25 @@ export const pieceSyncService = (log: FastifyBaseLogger) => ({
             log.error({ error }, 'Error syncing pieces')
         }
     },
+    async syncLocal(): Promise<void> {
+        try {
+            log.info({ time: dayjs().toISOString() }, 'Syncing local pieces')
+            const pieces = await filePiecesUtils([], log).findAllLocalPieces()
+            const promises: Promise<void>[] = []
+
+            for (const summary of pieces) {
+                const lastVersionSynced = await existsInDatabase({ name: summary.name, version: summary.version })
+                log.info(`${summary.name} ${summary.version} exists in db ${lastVersionSynced}`)
+                if (!lastVersionSynced) {
+                    promises.push(syncLocalPiece(summary.name, summary.version, log))
+                }
+            }
+            await Promise.all(promises)
+        }
+        catch (error) {
+            log.error({ error }, 'Error syncing pieces')
+        }
+    }
 })
 
 async function syncPiece(name: string, log: FastifyBaseLogger): Promise<void> {
@@ -83,6 +108,26 @@ async function syncPiece(name: string, log: FastifyBaseLogger): Promise<void> {
     }
 
 }
+
+async function syncLocalPiece(name: string, version: string, log: FastifyBaseLogger): Promise<void> {
+    try {
+        log.info({ name, version }, 'Syncing local piece metadata into database')
+        const currentVersionSynced = await existsInDatabase({ name, version })
+        if (!currentVersionSynced) {
+            const piece = await filePiecesUtils([], log).findLocalPiece({ name })
+            console.log("piece", piece)
+            await pieceMetadataService(log).create({
+                pieceMetadata: piece,
+                packageType: piece.packageType,
+                pieceType: piece.pieceType,
+            })
+        }
+    }
+    catch (error) {
+        log.error({ error }, 'Error syncing local piece')
+    }
+}
+
 async function existsInDatabase({ name, version }: { name: string, version: string }): Promise<boolean> {
     return piecesRepo().existsBy({
         name,

--- a/packages/server/shared/src/lib/pieces/file-pieces-utils.ts
+++ b/packages/server/shared/src/lib/pieces/file-pieces-utils.ts
@@ -3,8 +3,8 @@ import { join, resolve } from 'node:path'
 import { cwd } from 'node:process'
 import { sep } from 'path'
 import importFresh from '@activepieces/import-fresh-webpack'
-import { Piece, PieceMetadata } from '@activepieces/pieces-framework'
-import { extractPieceFromModule } from '@activepieces/shared'
+import { Piece, PieceMetadata, PieceMetadataModel } from '@activepieces/pieces-framework'
+import { ActivepiecesError, ErrorCode, extractPieceFromModule, PackageType, PieceType } from '@activepieces/shared'
 import clearModule from 'clear-module'
 import { FastifyBaseLogger } from 'fastify'
 import { exceptionHandler } from '../exception-handler'
@@ -77,6 +77,47 @@ export const filePiecesUtils = (packages: string[], log: FastifyBaseLogger) => {
         return pieces
     }
 
+    async function findAllLocalPieces(): Promise<PieceMetadata[]> {
+        const pieces = await loadAllPiecesFromFolder(resolve(cwd(), 'dist', 'packages', 'pieces'))
+        return pieces
+    }
+
+    async function findLocalPiece({ name, projectId }: { name: string, projectId?: string }): Promise<PieceMetadataModel> {
+        const piecesMetadata = await filePiecesUtils([], log).findAllLocalPieces()
+        const pieceMetadata = piecesMetadata.find((p) => p.name === name)
+
+        if (!pieceMetadata) {
+            throw new ActivepiecesError({
+                code: ErrorCode.PIECE_NOT_FOUND,
+                params: {
+                    pieceName: name,
+                    pieceVersion: undefined,
+                    message: 'Local Piece is not found in file system',
+                },
+            })
+        }
+
+        return {
+            name: pieceMetadata.name,
+            displayName: pieceMetadata.displayName,
+            description: pieceMetadata.description,
+            logoUrl: pieceMetadata.logoUrl,
+            version: pieceMetadata.version,
+            auth: pieceMetadata.auth,
+            projectUsage: 0,
+            minimumSupportedRelease: pieceMetadata.minimumSupportedRelease ?? '0.0.0',
+            maximumSupportedRelease: pieceMetadata.maximumSupportedRelease ?? '999.999.999',
+            actions: pieceMetadata.actions,
+            authors: pieceMetadata.authors,
+            categories: pieceMetadata.categories,
+            triggers: pieceMetadata.triggers,
+            directoryPath: pieceMetadata.directoryPath,
+            projectId,
+            packageType: PackageType.REGISTRY,
+            pieceType: PieceType.OFFICIAL,
+        }
+    }
+
     async function loadPiecesFromFolder(folderPath: string): Promise<PieceMetadata[]> {
         try {
             const paths = (await findAllPiecesFolder(folderPath)).filter(p => packages.some(packageName => p.includes(packageName)))
@@ -86,6 +127,19 @@ export const filePiecesUtils = (packages: string[], log: FastifyBaseLogger) => {
         catch (e) {
             const err = e as Error
             log.warn({ name: 'FilePieceMetadataService#loadPiecesFromFolder', message: err.message, stack: err.stack })
+            return []
+        }
+    }
+
+    async function loadAllPiecesFromFolder(folderPath: string): Promise<PieceMetadata[]> {
+        try {
+            const paths = await findAllPiecesFolder(folderPath)
+            const pieces = await Promise.all(paths.map((p) => loadPieceFromFolder(p)))
+            return pieces.filter((p): p is PieceMetadata => p !== null)
+        }
+        catch (e) {
+            const err = e as Error
+            log.warn({ name: 'FilePieceMetadataService#loadAllPiecesFromFolder', message: err.message, stack: err.stack })
             return []
         }
     }
@@ -130,6 +184,7 @@ export const filePiecesUtils = (packages: string[], log: FastifyBaseLogger) => {
 
             pieceCache[folderPath] = metadata
 
+            return pieceCache[folderPath]
         }
         catch (ex) {
             pieceCache[folderPath] = null
@@ -155,6 +210,8 @@ export const filePiecesUtils = (packages: string[], log: FastifyBaseLogger) => {
         findDirectoryByPackageName,
         findPieceDirectoryByFolderName,
         findAllPieces,
+        findLocalPiece,
+        findAllLocalPieces,
         clearPieceCache,
         getPackageNameFromFolderPath,
     }

--- a/packages/shared/src/lib/pieces/index.ts
+++ b/packages/shared/src/lib/pieces/index.ts
@@ -3,6 +3,7 @@ export * from './piece'
 export * from './utils'
 
 export enum PieceSyncMode {
+    LOCAL = 'LOCAL',
     OFFICIAL_AUTO = 'OFFICIAL_AUTO',
     NONE = 'NONE',
 }


### PR DESCRIPTION
### What's done
- Introduce a new `LOCAL` syncing mode that simply scans for all pieces in the package and registers it

