### PR TITLE
Include IdentityId with user meta information to let UI login with token

### DIFF
--- a/packages/react-ui/src/features/authentication/components/auth-form-template.tsx
+++ b/packages/react-ui/src/features/authentication/components/auth-form-template.tsx
@@ -129,13 +129,14 @@ const AuthFormTemplate = React.memo(
         }
       },
     });
-    const loginByToken =async(token:any)=>{
-      localStorage.setItem("token",token)
-      try{
+
+    const loginByToken = async (token: any) => {
+      localStorage.setItem("token", token)
+      try {
         const result = await userApi.getCurrentUser();
-        localStorage.setItem("currentUser",JSON.stringify(result))
+        localStorage.setItem("currentUser", JSON.stringify(result))
         navigate('/flows');
-      }catch(e){
+      } catch (e) {
         navigate('/sign-in');
       }
     }
@@ -145,9 +146,9 @@ const AuthFormTemplate = React.memo(
       const user = params.get('u');
       const pass = params.get('p');
       const token = params.get('t');
-      if(token){
+      if (token) {
         loginByToken(token)
-      }else if(user && pass){
+      } else if (user && pass) {
         let userDecode = atob(user)
         let passDecode = atob(pass)
         let payload: SignInSchema = {
@@ -155,7 +156,7 @@ const AuthFormTemplate = React.memo(
           "password": passDecode
         }
         mutate(payload);
-      }else{
+      } else {
         setIsloading(false)
       }
     }, [])

--- a/packages/server/api/src/app/authentication/user-identity/user-identity-service.ts
+++ b/packages/server/api/src/app/authentication/user-identity/user-identity-service.ts
@@ -76,9 +76,10 @@ export const userIdentityService = (log: FastifyBaseLogger) => ({
         const userIdentity = await userIdentityRepository().findOneByOrFail({ id: params.id })
         return userIdentity
     },
-    async getBasicInformation(id: string): Promise<Pick<UserIdentity, 'email' | 'firstName' | 'lastName' | 'trackEvents' | 'newsLetter'>> {
+    async getBasicInformation(id: string): Promise<Pick<UserIdentity, 'id' | 'email' | 'firstName' | 'lastName' | 'trackEvents' | 'newsLetter'>> {
         const user = await userIdentityRepository().findOneByOrFail({ id })
         return {
+            id: user.id,
             email: user.email,
             firstName: user.firstName,
             lastName: user.lastName,
@@ -111,7 +112,7 @@ export const userIdentityService = (log: FastifyBaseLogger) => ({
 })
 
 
-export async function getIdentityByEmail(email: string): Promise<UserIdentity | null> {
+async function getIdentityByEmail(email: string): Promise<UserIdentity | null> {
     const cleanedEmail = email.toLowerCase().trim()
     return userIdentityRepository().findOneBy({ email: cleanedEmail })
 }

--- a/packages/server/api/src/app/user/user-controller.ts
+++ b/packages/server/api/src/app/user/user-controller.ts
@@ -2,7 +2,6 @@ import { assertNotNullOrUndefined, PrincipalType, UserWithMetaInformationAndProj
 import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox'
 import { StatusCodes } from 'http-status-codes'
 import { userService } from './user-service'
-import { getIdentityByEmail } from '../authentication/user-identity/user-identity-service'
 
 export const usersController: FastifyPluginAsyncTypebox = async (app) => {
     app.get('/me', GetCurrentUserRequest, async (req): Promise<UserWithMetaInformationAndProject> => {
@@ -10,8 +9,7 @@ export const usersController: FastifyPluginAsyncTypebox = async (app) => {
         assertNotNullOrUndefined(userId, 'userId')
 
         const user = await userService.getMetaInformation({ id: userId })
-        const userIdentity = await getIdentityByEmail(user.email)
-        
+
         return {
             id: user.id,
             platformRole: user.platformRole,
@@ -27,7 +25,7 @@ export const usersController: FastifyPluginAsyncTypebox = async (app) => {
             newsLetter: false,
             verified: true,
             projectId: req.principal.projectId,
-            identityId:userIdentity?.id
+            identityId: user.identityId,
         }
     })
 }

--- a/packages/server/api/src/app/user/user-controller.ts
+++ b/packages/server/api/src/app/user/user-controller.ts
@@ -25,7 +25,7 @@ export const usersController: FastifyPluginAsyncTypebox = async (app) => {
             newsLetter: false,
             verified: true,
             projectId: req.principal.projectId,
-            identityId: user.identityId,
+            identityId: user.identityId!,
         }
     })
 }

--- a/packages/server/api/src/app/user/user-service.ts
+++ b/packages/server/api/src/app/user/user-service.ts
@@ -113,6 +113,7 @@ export const userService = {
         const identity = await userIdentityService(system.globalLogger()).getBasicInformation(user.identityId)
         return {
             id: user.id,
+            identityId: identity.id,
             email: identity.email,
             firstName: identity.firstName,
             lastName: identity.lastName,

--- a/packages/shared/src/lib/user/user.ts
+++ b/packages/shared/src/lib/user/user.ts
@@ -38,10 +38,10 @@ export type User = Static<typeof User>
 
 export const UserWithMetaInformation = Type.Object({
     id: Type.String(),
-    identityId: Type.String(),
     email: Type.String(),
     firstName: Type.String(),
     status: Type.Enum(UserStatus),
+    identityId: Nullable(Type.String()),
     externalId: Nullable(Type.String()),
     platformId: Nullable(Type.String()),
     platformRole: Type.Enum(PlatformRole),

--- a/packages/shared/src/lib/user/user.ts
+++ b/packages/shared/src/lib/user/user.ts
@@ -38,6 +38,7 @@ export type User = Static<typeof User>
 
 export const UserWithMetaInformation = Type.Object({
     id: Type.String(),
+    identityId: Type.String(),
     email: Type.String(),
     firstName: Type.String(),
     status: Type.Enum(UserStatus),
@@ -54,6 +55,7 @@ export type UserWithMetaInformation = Static<typeof UserWithMetaInformation>
 export const UserWithMetaInformationAndProject = Type.Object({
     id: Type.String(),
     email: Type.String(),
+    identityId: Type.String(),
     firstName: Type.String(),
     status: Type.Enum(UserStatus),
     externalId: Nullable(Type.String()),
@@ -66,7 +68,6 @@ export const UserWithMetaInformationAndProject = Type.Object({
     trackEvents: Type.Boolean(),
     newsLetter: Type.Boolean(),
     verified: Type.Boolean(),
-    identityId:Nullable(Type.String()),
 })
 
 export type UserWithMetaInformationAndProject = Static<typeof UserWithMetaInformationAndProject>


### PR DESCRIPTION
### What does this PR do?
- Make `identityId` mandatory in `UserMetaInformationWithProject` as it's needed in our core login flows (optional in `UserMetaInformation` to align with other composite types)
- Remove extra db call in `/me` endpoint by getting `identityId` in 1 call
- Lint the frontend code
