### PR TITLE
fix: promp-143 add console log to track community template 404

### DIFF
--- a/packages/server/api/src/app/flow-templates/community-flow-template.module.ts
+++ b/packages/server/api/src/app/flow-templates/community-flow-template.module.ts
@@ -33,6 +33,9 @@ const flowTemplateController: FastifyPluginAsyncTypebox = async (fastify) => {
             }
             const queryString = convertToQueryString(request.query)
             const url = `${templateSource}?${queryString}`
+            console.log("templateSource => ",templateSource);
+            console.log("queryString =>", queryString);
+            console.log("community template URL => ", url)
             const response = await fetch(url, {
                 method: 'GET',
                 headers: {


### PR DESCRIPTION
### What does

- generate console log to track for flow-templates/community 404 issue
