### PR TITLE
[PROMP-143] use activepieces community template api directly in community controller

### DIFF
--- a/packages/server/api/src/app/flow-templates/community-flow-template.module.ts
+++ b/packages/server/api/src/app/flow-templates/community-flow-template.module.ts
@@ -27,7 +27,10 @@ const flowTemplateController: FastifyPluginAsyncTypebox = async (fastify) => {
             },
         },
         async (request) => {
-            const templateSource = system.get(AppSystemProp.TEMPLATES_SOURCE_URL)
+            //todo (htookyaw or rupal) fix temporary to use the correct activepieces community template
+            // const templateSource = system.get(AppSystemProp.TEMPLATES_SOURCE_URL)
+            const templateSource = "https://cloud.activepieces.com/api/v1/flow-templates";
+            
             if (isNil(templateSource)) {
                 return paginationHelper.createPage([], null)
             }

--- a/packages/server/api/src/app/flow-templates/community-flow-template.module.ts
+++ b/packages/server/api/src/app/flow-templates/community-flow-template.module.ts
@@ -35,7 +35,7 @@ const flowTemplateController: FastifyPluginAsyncTypebox = async (fastify) => {
             const url = `${templateSource}?${queryString}`
             console.log("templateSource => ",templateSource);
             console.log("queryString =>", queryString);
-            console.log("community template URL => ", url)
+            console.log("community template URL => ", url);
             const response = await fetch(url, {
                 method: 'GET',
                 headers: {


### PR DESCRIPTION
### What done?

- use cloud.activepieces URL directly in controller for community templates

