### PR TITLE
[PROMP-140] Cloud flow templates API 

### DIFF
--- a/packages/react-ui/src/features/flows/components/select-flow-template-dialog.tsx
+++ b/packages/react-ui/src/features/flows/components/select-flow-template-dialog.tsx
@@ -138,11 +138,16 @@ const SelectFlowTemplateDialog = ({
   const { data: templates, isLoading } = useQuery<FlowTemplate[], Error>({
     queryKey: ['templates', activeTab],
     queryFn: async () => {
-      const templates =
-        activeTab === 'MY_TEMPLATE'
-          ? await templatesApi.list()
-          : await templatesApi.listCommunity();
-      return templates.data;
+      if (activeTab === 'MY_TEMPLATE') {
+        return (await templatesApi.list()).data;
+      }
+      
+      const [communityTemplates, cloudTemplates] = await Promise.all([
+        templatesApi.listCommunity(),
+        templatesApi.listCloud(),
+      ]);
+      
+      return [ ...communityTemplates.data, ...cloudTemplates.data ];
     },
     staleTime: 0,
   });

--- a/packages/react-ui/src/features/flows/components/select-flow-template-dialog.tsx
+++ b/packages/react-ui/src/features/flows/components/select-flow-template-dialog.tsx
@@ -142,12 +142,15 @@ const SelectFlowTemplateDialog = ({
         return (await templatesApi.list()).data;
       }
       
-      const [communityTemplates, cloudTemplates] = await Promise.all([
+      const results = await Promise.allSettled([
         templatesApi.listCommunity(),
         templatesApi.listCloud(),
       ]);
-      
-      return [ ...communityTemplates.data, ...cloudTemplates.data ];
+  
+      const communityTemplates = results[0].status === 'fulfilled' ? results[0].value.data : [];
+      const cloudTemplates = results[1].status === 'fulfilled' ? results[1].value.data : [];
+  
+      return [ ...communityTemplates, ...cloudTemplates ];
     },
     staleTime: 0,
   });

--- a/packages/react-ui/src/features/templates/lib/templates-api.ts
+++ b/packages/react-ui/src/features/templates/lib/templates-api.ts
@@ -19,6 +19,9 @@ export const templatesApi = {
   listCommunity(request?: ListFlowTemplatesRequest) {
     return api.get<SeekPage<FlowTemplate>>(`/v1/flow-templates/community`, request ?? {});
   },
+  listCloud(request?: ListFlowTemplatesRequest) {
+    return api.get<SeekPage<FlowTemplate>>(`/v1/flow-templates/cloud`, request ?? {});
+  },
   delete(templateId: string) {
     return api.delete<void>(`/v1/flow-templates/${templateId}`);
   },

--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -62,6 +62,7 @@ import { getRedisConnection } from './database/redis-connection'
 import { fileModule } from './file/file.module'
 import { flagModule } from './flags/flag.module'
 // import { flagHooks } from './flags/flags.hooks'
+import { cloudFlowTemplateModule } from './flow-templates/cloud-flow-template.module'
 import { communityFlowTemplateModule } from './flow-templates/community-flow-template.module'
 import { flowTemplateModule } from './flow-templates/flow-template.module'
 import { humanInputModule } from './flows/flow/human-input/human-input.module'
@@ -237,6 +238,7 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
     await app.register(tablesModule)
     await app.register(userModule)
     await app.register(flowTemplateModule)
+    await app.register(cloudFlowTemplateModule)
     await app.register(globalOAuthAppModule)
     await app.register(oauthAppModule)
     await app.register(todoModule)

--- a/packages/server/api/src/app/flow-templates/cloud-flow-template.module.ts
+++ b/packages/server/api/src/app/flow-templates/cloud-flow-template.module.ts
@@ -1,0 +1,32 @@
+import { AppSystemProp } from '@activepieces/server-shared'
+import {
+    ALL_PRINCIPAL_TYPES,
+    ListFlowTemplatesRequest,
+} from '@activepieces/shared'
+import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox'
+import { system } from '../helper/system/system'
+import { platformService } from '../platform/platform.service'
+import { flowTemplateService } from './flow-template.service'
+
+const ListFlowParams = {
+    config: {
+        allowedPrincipals: ALL_PRINCIPAL_TYPES,
+    },
+    schema: {
+        tags: ['flow-templates'],
+        description: 'List cloud flow templates',
+        querystring: ListFlowTemplatesRequest,
+    },
+}
+
+export const cloudFlowTemplateModule: FastifyPluginAsyncTypebox = async (app) => {
+    await app.register(flowTemplateController, { prefix: '/v1/flow-templates/cloud' })
+}
+
+const flowTemplateController: FastifyPluginAsyncTypebox = async (fastify) => {
+    fastify.get('/', ListFlowParams, async (request) => {
+        const cloudPlatformId = system.getOrThrow(AppSystemProp.CLOUD_PLATFORM_ID)
+        const platform = await platformService.getOneOrThrow(cloudPlatformId)
+        return flowTemplateService.list(platform.id, request.query)
+    })
+}


### PR DESCRIPTION
### What does this PR do?
- Exposed a new endpoint `/v1/flow-templates/cloud/` that gets global flow templates
- Templates are picked from `cloud` platform, i.e. ours (which means we need to create one and add to env)
- FE will call both community and cloud templates endpoint and show the result of both
