### PR TITLE
fix: Allow logins and redirects using token and from query string parameters

### DIFF
--- a/packages/react-ui/src/components/custom/FloatingChatButton.tsx
+++ b/packages/react-ui/src/components/custom/FloatingChatButton.tsx
@@ -5,8 +5,8 @@ import 'react-quill/dist/quill.snow.css';
 import './FloatingChatButton.css';
 import { Avatar, AvatarFallback } from '../ui/avatar';
 import { AvatarLetter } from '../ui/avatar-letter';
-import { authenticationSession } from '@/lib/authentication-session';
 import { useEmbedding } from '../embed-provider';
+import { userHooks } from '@/hooks/user-hooks';
 
 export const modulesChat = {
   toolbar: [
@@ -21,7 +21,7 @@ export const modulesChat = {
 export const FloatingChatButton: React.FC = () => {
   const chatContainerRef = useRef<HTMLDivElement | null>(null);
   const { embedState } = useEmbedding();
-  const user = authenticationSession.getCurrentUser();
+  const { data: user } = userHooks.useCurrentUser();
   if (!user || embedState.isEmbedded) {
     return null;
   }

--- a/packages/react-ui/src/components/ui/user-avatar.tsx
+++ b/packages/react-ui/src/components/ui/user-avatar.tsx
@@ -1,10 +1,11 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { LogOut, SunMoon } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 import { useEmbedding } from '@/components/embed-provider';
 import { useTelemetry } from '@/components/telemetry-provider';
-import { authenticationSession } from '@/lib/authentication-session';
+import { userHooks } from '@/hooks/user-hooks';
 
 import { Avatar, AvatarFallback } from './avatar';
 import { AvatarLetter } from './avatar-letter';
@@ -20,7 +21,8 @@ import { TextWithIcon } from './text-with-icon';
 export function UserAvatar() {
   const { reset } = useTelemetry();
   const { embedState } = useEmbedding();
-  const user = authenticationSession.getCurrentUser();
+  const { data: user } = userHooks.useCurrentUser();
+  const queryClient = useQueryClient();
   if (!user || embedState.isEmbedded) {
     return null;
   }

--- a/packages/react-ui/src/features/authentication/components/auth-form-template.tsx
+++ b/packages/react-ui/src/features/authentication/components/auth-form-template.tsx
@@ -73,7 +73,7 @@ const AuthFormTemplate = React.memo(
     const isSignUp = form === 'signup';
     const [searchParams] = useSearchParams();
     const from = searchParams.get('from');
-    const tokenFromUrl = searchParams.get('t');
+    const tokenFromUrl = searchParams.get('token');
     const token = authenticationSession.getToken();
 
     // To redirect to PromptX login page

--- a/packages/react-ui/src/features/authentication/components/auth-form-template.tsx
+++ b/packages/react-ui/src/features/authentication/components/auth-form-template.tsx
@@ -1,6 +1,6 @@
 import { t } from 'i18next';
 import React, { useEffect, useState } from 'react';
-import { Link, Navigate, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, Navigate, useSearchParams } from 'react-router-dom';
 
 import {
   Card,
@@ -11,9 +11,7 @@ import {
 } from '@/components/ui/card';
 import {
   ApFlagId,
-  AuthenticationResponse,
   isNil,
-  SignInRequest,
   ThirdPartyAuthnProvidersToShowMap,
 } from '@activepieces/shared';
 
@@ -23,13 +21,7 @@ import { flagsHooks } from '../../../hooks/flags-hooks';
 import { SignInForm } from './sign-in-form';
 // import { SignUpForm } from './sign-up-form';
 import { ThirdPartyLogin } from './third-party-logins';
-import { useMutation } from '@tanstack/react-query';
-import { HttpError } from '@activepieces/pieces-common';
 import { authenticationSession } from '@/lib/authentication-session';
-import { authenticationApi } from '@/lib/authentication-api';
-import { ClipLoader } from 'react-spinners';
-import { api } from '@/lib/api';
-import { userApi } from '@/lib/user-api';
 
 const BottomNote = ({ isSignup }: { isSignup: boolean }) => {
   const [searchParams] = useSearchParams();
@@ -81,16 +73,18 @@ const AuthFormTemplate = React.memo(
     const isSignUp = form === 'signup';
     const [searchParams] = useSearchParams();
     const from = searchParams.get('from');
+    const tokenFromUrl = searchParams.get('t');
     const token = authenticationSession.getToken();
 
-    const [showCheckYourEmailNote, setShowCheckYourEmailNote] = useState(false);
-    let [isLoading, setIsLoading] = useState<boolean>(true);
-    const { data: isEmailAuthEnabled } = flagsHooks.useFlag<boolean>(
-      ApFlagId.EMAIL_AUTH_ENABLED
-    );
+    // To redirect to PromptX login page
     const { data: loginUrl } = flagsHooks.useFlag<string>(ApFlagId.LOGIN_URL);
     const { data: environment } = flagsHooks.useFlag<string>(
-      ApFlagId.ENVIRONMENT
+      ApFlagId.ENVIRONMENT,
+    );
+
+    const [showCheckYourEmailNote, setShowCheckYourEmailNote] = useState(false);
+    const { data: isEmailAuthEnabled } = flagsHooks.useFlag<boolean>(
+      ApFlagId.EMAIL_AUTH_ENABLED,
     );
     const data = {
       signin: {
@@ -105,58 +99,17 @@ const AuthFormTemplate = React.memo(
       },
     }[form];
 
-    const navigate = useNavigate();
+    if (token && from) {
+      return <Navigate to={from} />;
+    }
+
+    if (tokenFromUrl) {
+      authenticationSession.saveToken(tokenFromUrl);
+      const navigateTo = isNil(from) ? '/flows' : from;
+      return <Navigate to={navigateTo} />;
+    }
 
     const [countdown, setCountdown] = useState(3);
-
-    const { mutate, isPending } = useMutation<
-      AuthenticationResponse,
-      HttpError,
-      SignInRequest
-    >({
-      mutationFn: authenticationApi.signIn,
-      onSuccess: (payload) => {
-        authenticationSession.saveResponse(payload);
-        navigate('/flows');
-      },
-      onError: (error) => {
-        if (api.isError(error)) {
-          navigate('/sign-in');
-          return;
-        }
-      },
-    });
-
-    const loginByToken = async (token: any) => {
-      localStorage.setItem('token', token);
-      try {
-        const result = await userApi.getCurrentUser();
-        localStorage.setItem('currentUser', JSON.stringify(result));
-        navigate('/flows');
-      } catch (e) {
-        navigate('/sign-in');
-      }
-    };
-
-    useEffect(() => {
-      const params = new URLSearchParams(location.search);
-      const user = params.get('u');
-      const pass = params.get('p');
-      const token = params.get('t');
-      if (token) {
-        loginByToken(token);
-      } else if (user && pass) {
-        let userDecode = atob(user);
-        let passDecode = atob(pass);
-        let payload: SignInRequest = {
-          email: userDecode,
-          password: passDecode,
-        };
-        mutate(payload);
-      } else {
-        setIsLoading(false);
-      }
-    }, []);
 
     useEffect(() => {
       // For non-dev environments, we'd like to login via external screen
@@ -175,6 +128,7 @@ const AuthFormTemplate = React.memo(
         return () => clearInterval(timer);
       }
     }, []);
+
     // will redirect to promptX login page
     if (environment !== 'dev' && !isNil(loginUrl)) {
       return (
@@ -183,13 +137,6 @@ const AuthFormTemplate = React.memo(
             {t(`Logins are allowed only through CenterApp, Redirecting you in ${countdown}
             seconds...`)}
           </p>
-        </div>
-      );
-    }
-    if (isLoading) {
-      return (
-        <div className="flex justify-center items-center h-full">
-          <ClipLoader color="#a9a9a9" />
         </div>
       );
     }
@@ -226,7 +173,7 @@ const AuthFormTemplate = React.memo(
         <BottomNote isSignup={isSignUp}></BottomNote>
       </Card>
     );
-  }
+  },
 );
 
 AuthFormTemplate.displayName = 'AuthFormTemplate';

--- a/packages/react-ui/src/lib/authentication-session.ts
+++ b/packages/react-ui/src/lib/authentication-session.ts
@@ -4,24 +4,14 @@ import { jwtDecode } from 'jwt-decode';
 import { AuthenticationResponse, isNil, Principal } from '@activepieces/shared';
 
 import { authenticationApi } from './authentication-api';
-import { projectApi } from './project-api';
 
 const tokenKey = 'token';
-const currentUserKey = 'currentUser';
 export const authenticationSession = {
-  // saveResponse(response: AuthenticationResponse) {
-  //   localStorage.setItem(tokenKey, response.token);
-  //   window.dispatchEvent(new Event('storage'));
-  // },
+  saveToken(token: string) {
+    localStorage.setItem(tokenKey, token);
+  },
   saveResponse(response: AuthenticationResponse) {
     localStorage.setItem(tokenKey, response.token);
-    localStorage.setItem(
-      currentUserKey,
-      JSON.stringify({
-        ...response,
-        token: undefined,
-      }),
-    );
     window.dispatchEvent(new Event('storage'));
   },
   isJwtExpired(token: string): boolean {
@@ -50,16 +40,6 @@ export const authenticationSession = {
     const decodedJwt = getDecodedJwt(token);
     return decodedJwt.projectId;
   },
-  getPlatformId(): string | null {
-    return this.getCurrentUser()?.platformId ?? null;
-  },
-  getUserProjectRole() {
-    let obj: any = this.getCurrentUser();
-    return obj?.projectRole ?? null;
-  },
-  getUserPlatformRole() {
-    return this.getCurrentUser()?.platformRole ?? null;
-  },
   getCurrentUserId(): string | null {
     const token = this.getToken();
     if (isNil(token)) {
@@ -68,19 +48,6 @@ export const authenticationSession = {
     const decodedJwt = getDecodedJwt(token);
     return decodedJwt.id;
   },
-  async switchToSession(projectId: string) {
-    const result: any = await projectApi.getTokenForProject(projectId);
-    localStorage.setItem(tokenKey, result.token);
-    localStorage.setItem(
-      currentUserKey,
-      JSON.stringify({
-        ...this.getCurrentUser(),
-        projectId,
-        projectRole: result.projectRole,
-      })
-    );
-    window.dispatchEvent(new Event('storage'));
-  },
   appendProjectRoutePrefix(path: string): string {
     const projectId = this.getProjectId();
     if (isNil(projectId)) {
@@ -88,14 +55,14 @@ export const authenticationSession = {
     }
     return `/projects/${projectId}${path.startsWith('/') ? path : `/${path}`}`;
   },
-  // getPlatformId(): string | null {
-  //   const token = this.getToken();
-  //   if (isNil(token)) {
-  //     return null;
-  //   }
-  //   const decodedJwt = getDecodedJwt(token);
-  //   return decodedJwt.platform.id;
-  // },
+  getPlatformId(): string | null {
+    const token = this.getToken();
+    if (isNil(token)) {
+      return null;
+    }
+    const decodedJwt = getDecodedJwt(token);
+    return decodedJwt.platform.id;
+  },
   async switchToPlatform(platformId: string) {
     if (authenticationSession.getPlatformId() === platformId) {
       return;
@@ -106,19 +73,16 @@ export const authenticationSession = {
     localStorage.setItem(tokenKey, result.token);
     window.location.href = '/';
   },
-  // async switchToSession(projectId: string) {
-  //   if (authenticationSession.getProjectId() === projectId) {
-  //     return;
-  //   }
-  //   const result = await authenticationApi.switchProject({ projectId });
-  //   localStorage.setItem(tokenKey, result.token);
-  //   window.dispatchEvent(new Event('storage'));
-  // },
-  // isLoggedIn(): boolean {
-  //   return !!this.getToken();
-  // },
+  async switchToSession(projectId: string) {
+    if (authenticationSession.getProjectId() === projectId) {
+      return;
+    }
+    const result = await authenticationApi.switchProject({ projectId });
+    localStorage.setItem(tokenKey, result.token);
+    window.dispatchEvent(new Event('storage'));
+  },
   isLoggedIn(): boolean {
-    return !!this.getToken() && !!this.getCurrentUser();
+    return !!this.getToken();
   },
   clearSession() {
     localStorage.removeItem(tokenKey);
@@ -126,18 +90,6 @@ export const authenticationSession = {
   logOut() {
     this.clearSession();
     window.location.href = '/sign-in';
-  },
-  getCurrentUser(): AuthenticationResponse | null {
-    const user = localStorage.getItem(currentUserKey);
-    if (user) {
-      try {
-        return JSON.parse(user);
-      } catch (e) {
-        console.error(e);
-        return null;
-      }
-    }
-    return null;
   },
 };
 


### PR DESCRIPTION
### What does this PR do?
- Allow direct login through `t` query string parameter
- Allow redirects using `from` query string parameter
- Maintain existing log in scenarios too
- Misc. Update references to `getCurrentUser` to use hooks instead

Example `localhost:4200/sign-in?from=%2Fflows%2FxvN54uWsxgOctMa8kKrFA&token=<unescaped-jwt-token>`
