### PR TITLE
feat(analytics): create 2 APIs for analytics flow-performance and overview

### DIFF
--- a/packages/server/api/src/app/analytics/analytics-controller.ts
+++ b/packages/server/api/src/app/analytics/analytics-controller.ts
@@ -1,90 +1,88 @@
 import { AnalyticsResponseSchema, GetAnalyticsParams, OverviewResponseSchema } from '@activepieces/shared'
 import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox'
-import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { analyticsService } from './analytics-service'
-import 'tslib'
 
-const errorResponseObj = {
+const ErrorResponse = {
     type: 'object',
     properties: {
         message: { type: 'string' },
     },
 }
 
-const analyticsRequest = {
+const AnalyticsRequest = {
+    config: {},
     schema: {
         tags: ['analytics'],
         description: 'Get analytics data for flow-runs',
         querystring: GetAnalyticsParams,
         response: {
             [StatusCodes.OK]: AnalyticsResponseSchema,
-            [StatusCodes.BAD_REQUEST]: errorResponseObj,
-            [StatusCodes.INTERNAL_SERVER_ERROR]: errorResponseObj,
+            [StatusCodes.BAD_REQUEST]: ErrorResponse,
+            [StatusCodes.INTERNAL_SERVER_ERROR]: ErrorResponse,
         },
     },
 }
 
-const overviewRequest = {
+const OverviewRequest = {
+    config: {},
     schema: {
         tags: ['analytics'],
         description: 'Get workflow overview statistics',
         response: {
             [StatusCodes.OK]: OverviewResponseSchema,
-            [StatusCodes.INTERNAL_SERVER_ERROR]: errorResponseObj,
+            [StatusCodes.INTERNAL_SERVER_ERROR]: ErrorResponse,
         },
     },
 }
 
-export const analyticsController: FastifyPluginAsyncTypebox = async (app: FastifyInstance) => {
-    app.get('/workflow-performance',
-        analyticsRequest,
-        async (request: FastifyRequest, reply: FastifyReply) => {
-            try {
-                const { startDate, endDate } = request.query as GetAnalyticsParams
+export const analyticsController: FastifyPluginAsyncTypebox = async (app) => {
+    app.get('/flow-performance', AnalyticsRequest, async (request, reply) => {
+        try {
+            const { startDate, endDate } = request.query
 
-                // Convert timestamps to Date objects for comparison
-                const start = new Date(startDate)
-                const end = new Date(endDate)
-                const currentDateTime = new Date()
+            // Convert timestamps to Date objects for comparison
+            const start = new Date(startDate)
+            const end = new Date(endDate)
+            const currentDateTime = new Date()
 
-                // Validate timestamps
-                if (isNaN(start.getTime()) || isNaN(end.getTime())) {
-                    return await reply.status(StatusCodes.BAD_REQUEST).send({
-                        message: 'Invalid date format. Please provide valid dates.',
-                    })
-                }
-
-                // Validate date range
-                if (start.getTime() >= end.getTime()) {
-                    return await reply.status(StatusCodes.BAD_REQUEST).send({
-                        message: 'startDate must be less than endDate',
-                    })
-                }
-
-                // Validate future dates
-                if (start.getTime() > currentDateTime.getTime() || end.getTime() > currentDateTime.getTime()) {
-                    return await reply.status(StatusCodes.BAD_REQUEST).send({
-                        message: 'Dates cannot be in the future',
-                    })
-                }
-
-                const analyticsData = await analyticsService.getAnalyticsData({
-                    startDate,
-                    endDate,
-                })
-
-                return await reply.send(analyticsData)
-            }
-            catch (error) {
-                app.log.error('Error fetching analytics data:', error)
-                return reply.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
-                    message: 'An error occurred while fetching analytics data',
+            // Validate timestamps
+            if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+                return await reply.status(StatusCodes.BAD_REQUEST).send({
+                    message: 'Invalid date format. Please provide valid dates.',
                 })
             }
-        },
-    ),
-    app.get('/overview', overviewRequest, async (request: FastifyRequest, reply: FastifyReply) => {
+
+            // Validate date range
+            if (start.getTime() >= end.getTime()) {
+                return await reply.status(StatusCodes.BAD_REQUEST).send({
+                    message: 'startDate must be less than endDate',
+                })
+            }
+
+            // Validate future dates
+            if (start.getTime() > currentDateTime.getTime() || end.getTime() > currentDateTime.getTime()) {
+                return await reply.status(StatusCodes.BAD_REQUEST).send({
+                    message: 'Dates cannot be in the future',
+                })
+            }
+
+            const analyticsData = await analyticsService.getAnalyticsData({
+                startDate,
+                endDate,
+            })
+
+            return await reply.send(analyticsData)
+        }
+        catch (error) {
+            app.log.error('Error fetching analytics data:', error)
+            return reply.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+                message: 'An error occurred while fetching analytics data',
+            })
+        }
+    })
+
+    app.get('/overview', OverviewRequest, async (request, reply) => {
         try {
             const overviewData = await analyticsService.getWorkflowOverview()
             return await reply.send(overviewData)
@@ -97,4 +95,3 @@ export const analyticsController: FastifyPluginAsyncTypebox = async (app: Fastif
         }
     })
 }
-

--- a/packages/server/api/src/app/analytics/analytics-module.ts
+++ b/packages/server/api/src/app/analytics/analytics-module.ts
@@ -1,6 +1,6 @@
-import { FastifyPluginAsync, FastifyInstance } from 'fastify'
+import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox'
 import { analyticsController } from './analytics-controller'
 
-export const analyticsModule: FastifyPluginAsync = async (app: FastifyInstance) => {
+export const analyticsModule: FastifyPluginAsyncTypebox = async (app) => {
     await app.register(analyticsController, { prefix: '/v1/analytics' })
 }

--- a/packages/server/api/src/app/analytics/analytics-module.ts
+++ b/packages/server/api/src/app/analytics/analytics-module.ts
@@ -1,6 +1,6 @@
-import { FastifyPluginAsync } from 'fastify'
+import { FastifyPluginAsync, FastifyInstance } from 'fastify'
 import { analyticsController } from './analytics-controller'
 
-export const analyticsModule: FastifyPluginAsync = async (app) => {
+export const analyticsModule: FastifyPluginAsync = async (app: FastifyInstance) => {
     await app.register(analyticsController, { prefix: '/v1/analytics' })
 }

--- a/packages/server/api/src/app/analytics/analytics-service.ts
+++ b/packages/server/api/src/app/analytics/analytics-service.ts
@@ -1,8 +1,7 @@
-import { AnalyticsResult, FlowRunStatus, GetAnalyticsParams, FlowStatus,OverviewResult } from '@activepieces/shared'
-import { flowRunRepo } from '../flows/flow-run/flow-run-service'
-import { flowRepo } from '../flows/flow/flow.repo'
-import 'tslib'
+import { AnalyticsResult, FlowRunStatus, FlowStatus, GetAnalyticsParams, OverviewResult } from '@activepieces/shared'
 import dayjs from 'dayjs'
+import { flowRepo } from '../flows/flow/flow.repo'
+import { flowRunRepo } from '../flows/flow-run/flow-run-service'
 
 export const analyticsService = {
     async getAnalyticsData({
@@ -41,7 +40,7 @@ export const analyticsService = {
             .orderBy('date', 'ASC')
 
         const rawResults = await query.getRawMany()
-        
+
         const results: AnalyticsResult[] = rawResults.map(result => ({
             date: result.date,
             successfulFlowRuns: parseInt(result.successfulFlowRuns) || 0,
@@ -53,26 +52,25 @@ export const analyticsService = {
         return results
     },
     async getWorkflowOverview(): Promise<OverviewResult> {
-        const workflowCount = await flowRepo().count();
-        
+        const workflowCount = await flowRepo().count()
+
         const activeWorkflowCount = await flowRepo().count({
             where: {
-                status: FlowStatus.ENABLED
-            }
-        });
+                status: FlowStatus.ENABLED,
+            },
+        })
 
         const flowRunCount = await flowRunRepo().createQueryBuilder('flowRun')
             .where('flowRun.finishTime BETWEEN :start AND :end', {
                 start: dayjs().startOf('month').toISOString(),
-                end: dayjs().endOf('month').toISOString()
+                end: dayjs().endOf('month').toISOString(),
             })
-            .getCount();
+            .getCount()
 
         return {
             workflowCount,
             activeWorkflowCount,
-            flowRunCount
-        };
-    }
+            flowRunCount,
+        }
+    },
 }
-

--- a/packages/server/api/src/app/analytics/analytics-service.ts
+++ b/packages/server/api/src/app/analytics/analytics-service.ts
@@ -1,56 +1,78 @@
-import { AnalyticsResultMap, FlowRunStatus, GetAnalyticsParams } from '@activepieces/shared'
+import { AnalyticsResult, FlowRunStatus, GetAnalyticsParams, FlowStatus,OverviewResult } from '@activepieces/shared'
 import { flowRunRepo } from '../flows/flow-run/flow-run-service'
+import { flowRepo } from '../flows/flow/flow.repo'
+import 'tslib'
+import dayjs from 'dayjs'
 
 export const analyticsService = {
     async getAnalyticsData({
-        startTimestamp,
-        endTimestamp,
-    }: GetAnalyticsParams): Promise<AnalyticsResultMap> {
+        startDate,
+        endDate,
+    }: GetAnalyticsParams): Promise<AnalyticsResult[]> {
         const query = flowRunRepo()
             .createQueryBuilder('flowRun')
-            .select('flowRun.flowId', 'flowId')
-            .addSelect('COUNT(*)', 'flowRunCount')
-            .addSelect('AVG(flowRun.duration)', 'averageRuntime')
+            .select('DATE(flowRun.finishTime)', 'date')
+            .addSelect('COUNT(*)', 'totalFlowRuns')
             .addSelect(
                 'SUM(CASE WHEN flowRun.status = :successStatus THEN 1 ELSE 0 END)',
-                'successCount',
+                'successfulFlowRuns',
             )
             .addSelect(
                 'SUM(CASE WHEN flowRun.status = :failureStatus THEN 1 ELSE 0 END)',
-                'failureCount',
+                'failedFlowRuns',
             )
             .addSelect(
-                '(SUM(CASE WHEN flowRun.status = :successStatus THEN 1 ELSE 0 END) / COUNT(*)) * 100',
-                'successRate',
+                'SUM(CASE WHEN flowRun.status = :successStatus THEN flowRun.duration ELSE 0 END)',
+                'successfulFlowRunsDuration',
             )
             .addSelect(
-                '(SUM(CASE WHEN flowRun.status = :failureStatus THEN 1 ELSE 0 END) / COUNT(*)) * 100',
-                'failureRate',
+                'SUM(CASE WHEN flowRun.status = :failureStatus THEN flowRun.duration ELSE 0 END)',
+                'failedFlowRunsDuration',
             )
-            .where('flowRun.finishTime BETWEEN :start AND :end', {
-                start: startTimestamp.toString(),
-                end: endTimestamp.toString(),
+            .where('DATE(flowRun.finishTime) BETWEEN :start AND :end', {
+                start: startDate,
+                end: endDate,
             })
             .setParameters({
                 successStatus: FlowRunStatus.SUCCEEDED,
                 failureStatus: FlowRunStatus.FAILED,
             })
-            .groupBy('flowRun.flowId')
+            .groupBy('DATE(flowRun.finishTime)')
+            .orderBy('date', 'ASC')
 
         const rawResults = await query.getRawMany()
+        
+        const results: AnalyticsResult[] = rawResults.map(result => ({
+            date: result.date,
+            successfulFlowRuns: parseInt(result.successfulFlowRuns) || 0,
+            failedFlowRuns: parseInt(result.failedFlowRuns) || 0,
+            successfulFlowRunsDuration: parseInt(result.successfulFlowRunsDuration) || 0,
+            failedFlowRunsDuration: parseInt(result.failedFlowRunsDuration) || 0,
+        }))
 
-        const analytics: AnalyticsResultMap = {}
-
-        for (const result of rawResults) {
-            const flowId = result.flowId
-            analytics[flowId] = {
-                averageRuntime: parseFloat(result.averageRuntime) || 0,
-                flowRunCount: parseInt(result.flowRunCount, 10),
-                successRate: parseFloat(result.successRate) || 0,
-                failureRate: parseFloat(result.failureRate) || 0,
-            }
-        }
-
-        return analytics
+        return results
     },
+    async getWorkflowOverview(): Promise<OverviewResult> {
+        const workflowCount = await flowRepo().count();
+        
+        const activeWorkflowCount = await flowRepo().count({
+            where: {
+                status: FlowStatus.ENABLED
+            }
+        });
+
+        const flowRunCount = await flowRunRepo().createQueryBuilder('flowRun')
+            .where('flowRun.finishTime BETWEEN :start AND :end', {
+                start: dayjs().startOf('month').toISOString(),
+                end: dayjs().endOf('month').toISOString()
+            })
+            .getCount();
+
+        return {
+            workflowCount,
+            activeWorkflowCount,
+            flowRunCount
+        };
+    }
 }
+

--- a/packages/shared/src/lib/analytics/index.ts
+++ b/packages/shared/src/lib/analytics/index.ts
@@ -46,29 +46,46 @@ export type AnalyticsReportResponse = Static<typeof AnalyticsReportResponse>
 
 // Export GetAnalyticsParams
 export const GetAnalyticsParams = Type.Object({
-    startTimestamp: Type.String({ format: 'date-time' }),
-    endTimestamp: Type.String({ format: 'date-time' }),
+    startDate: Type.String({ format: 'date' }),
+    endDate: Type.String({ format: 'date' }),
 })
 export type GetAnalyticsParams = Static<typeof GetAnalyticsParams>
 
 // Export AnalyticsResult and AnalyticsResultMap
 export type AnalyticsResult = {
-    averageRuntime: number
-    flowRunCount: number
-    successRate: number
-    failureRate: number
+    date: string
+    successfulFlowRuns: number
+    failedFlowRuns: number
+    successfulFlowRunsDuration: number
+    failedFlowRunsDuration: number
 }
 
-export type AnalyticsResultMap = Record<string, AnalyticsResult>
-
 // Export AnalyticsResponseSchema
-export const AnalyticsResponseSchema = Type.Record(
-    Type.String(), // flowId as string key
+export const AnalyticsResponseSchema = Type.Array(
     Type.Object({
-        averageRuntime: Type.Number(),
-        flowRunCount: Type.Number(),
-        successRate: Type.Number(),
-        failureRate: Type.Number(),
-    }),
-)
+        date: Type.String(),
+        successfulFlowRuns: Type.Number(),
+        failedFlowRuns: Type.Number(),
+        successfulFlowRunsDuration: Type.Number(),
+        failedFlowRunsDuration: Type.Number(),
+    })
+);
 export type AnalyticsResponse = Static<typeof AnalyticsResponseSchema>
+
+
+
+//For Overview API
+export type OverviewResult = {
+    workflowCount: number
+    activeWorkflowCount: number
+    flowRunCount: number
+}
+export const  OverviewResponseSchema = Type.Object({
+    workflowCount: Type.Number(),
+    activeWorkflowCount: Type.Number(),
+    flowRunCount: Type.Number(),
+})
+
+
+export type OverviewResponse = Static<typeof OverviewResponseSchema>
+

--- a/packages/shared/src/lib/analytics/index.ts
+++ b/packages/shared/src/lib/analytics/index.ts
@@ -44,14 +44,12 @@ export type AnalyticsReportResponse = Static<typeof AnalyticsReportResponse>
 
 // Flow run analytics reports (custom)
 
-// Export GetAnalyticsParams
 export const GetAnalyticsParams = Type.Object({
     startDate: Type.String({ format: 'date' }),
     endDate: Type.String({ format: 'date' }),
 })
 export type GetAnalyticsParams = Static<typeof GetAnalyticsParams>
 
-// Export AnalyticsResult and AnalyticsResultMap
 export type AnalyticsResult = {
     date: string
     successfulFlowRuns: number
@@ -60,7 +58,6 @@ export type AnalyticsResult = {
     failedFlowRunsDuration: number
 }
 
-// Export AnalyticsResponseSchema
 export const AnalyticsResponseSchema = Type.Array(
     Type.Object({
         date: Type.String(),
@@ -68,24 +65,19 @@ export const AnalyticsResponseSchema = Type.Array(
         failedFlowRuns: Type.Number(),
         successfulFlowRunsDuration: Type.Number(),
         failedFlowRunsDuration: Type.Number(),
-    })
-);
+    }),
+)
 export type AnalyticsResponse = Static<typeof AnalyticsResponseSchema>
 
-
-
-//For Overview API
 export type OverviewResult = {
     workflowCount: number
     activeWorkflowCount: number
     flowRunCount: number
 }
+
 export const  OverviewResponseSchema = Type.Object({
     workflowCount: Type.Number(),
     activeWorkflowCount: Type.Number(),
     flowRunCount: Type.Number(),
 })
-
-
 export type OverviewResponse = Static<typeof OverviewResponseSchema>
-


### PR DESCRIPTION
### What's done
```
GET /api/v1/analytics/flow-performance?startDate=&endDate=
[
  {
    "date": "10-04-2025",
    "successfulFlowRuns": 80,
    "failedFlowRuns": 20,
    "successfulFlowRunsDuration": 300,
    "failedFlowRunsDuration": 100
  },
  {
    "date": "11-04-2025",
    "successfulFlowRuns": 80,
    "failedFlowRuns": 20,
    "successfulFlowRunsDuration": 300, // in milliseconds
    "failedFlowRunsDuration": 100 // in milliseconds
  },
  {
    "date": "12-04-2025",
    "successfulFlowRuns": 80,
    "failedFlowRuns": 20,
    "successfulFlowRunsDuration": 300, // in milliseconds
    "failedFlowRunsDuration": 100 // in milliseconds
  }
]

GET /api/v1/analytics/overview
{
  "workflowCount": 100,
  "activeWorkflowCount": 2,
  "flowRunCount": 400
}
```