### PR TITLE
fix: update sidebar header with only website name

### DIFF
--- a/packages/react-ui/src/app/components/ap-dashboard-sidebar-header.tsx
+++ b/packages/react-ui/src/app/components/ap-dashboard-sidebar-header.tsx
@@ -16,6 +16,7 @@ import { ProjectSwitcher } from '@/features/projects/components/project-switcher
 import { useAuthorization } from '@/hooks/authorization-hooks';
 import { flagsHooks } from '@/hooks/flags-hooks';
 import { cn, determineDefaultRoute } from '@/lib/utils';
+import { useTheme } from '@/components/theme-provider';
 
 const ApDashboardSidebarHeader = ({
   isHomeDashboard,
@@ -25,6 +26,7 @@ const ApDashboardSidebarHeader = ({
   const branding = flagsHooks.useWebsiteBranding();
   const { data: edition } = flagsHooks.useFlag<ApEdition>(ApFlagId.EDITION);
   const { embedState } = useEmbedding();
+  const { theme } = useTheme();
   const showProjectSwitcher =
     edition !== ApEdition.COMMUNITY && !embedState.isEmbedded;
   const defaultRoute = determineDefaultRoute(useAuthorization().checkAccess);
@@ -46,7 +48,7 @@ const ApDashboardSidebarHeader = ({
                     {/**
                      * sidebar header keep only website Name 
                      */}
-                  <h1 className="text-xl font-semibold text-gray-900">{branding.websiteName}</h1>
+                  <h1 className={`text-xl font-semibold ${theme === 'light'? 'text-gray-900' : ''}`}>{branding.websiteName}</h1>
                     {/* {showProjectSwitcher ? (
                       <img
                         src={branding.logos.logoIconUrl}

--- a/packages/react-ui/src/app/components/ap-dashboard-sidebar-header.tsx
+++ b/packages/react-ui/src/app/components/ap-dashboard-sidebar-header.tsx
@@ -32,20 +32,22 @@ const ApDashboardSidebarHeader = ({
   return (
     <SidebarHeader className="pb-0 ">
       <div
-        className={cn('flex items-center justify-between pr-1', {
-          'justify-center': !showProjectSwitcher,
-        })}
+        className='flex items-center justify-between pr-1'
       >
-        <div className="flex items-center justify-center gap-1">
+        <div className="flex items-center gap-1">
           <div className="relative">
             <Button variant="ghost">
               <Link
                 to={isHomeDashboard ? defaultRoute : '/platform'}
-                className="flex items-center justify-center"
+                className="flex items-center"
               >
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    {showProjectSwitcher ? (
+                    {/**
+                     * sidebar header keep only website Name 
+                     */}
+                  <h1 className="text-xl font-semibold text-gray-900">{branding.websiteName}</h1>
+                    {/* {showProjectSwitcher ? (
                       <img
                         src={branding.logos.logoIconUrl}
                         alt={t('home')}
@@ -61,7 +63,7 @@ const ApDashboardSidebarHeader = ({
                         height={51}
                         className="max-h-[51px] max-w-[160px] object-contain"
                       />
-                    )}
+                    )} */}
                   </TooltipTrigger>
                   <TooltipContent side="bottom">{t('Home')}</TooltipContent>
                 </Tooltip>

--- a/packages/react-ui/src/app/components/ap-dashboard-sidebar-header.tsx
+++ b/packages/react-ui/src/app/components/ap-dashboard-sidebar-header.tsx
@@ -34,14 +34,16 @@ const ApDashboardSidebarHeader = ({
   return (
     <SidebarHeader className="pb-0 ">
       <div
-        className='flex items-center justify-between pr-1'
+        className={cn('flex items-center justify-between pr-1', {
+          'justify-center': false,
+        })}
       >
-        <div className="flex items-center gap-1">
+        <div className="flex items-center justify-center gap-1">
           <div className="relative">
             <Button variant="ghost">
               <Link
                 to={isHomeDashboard ? defaultRoute : '/platform'}
-                className="flex items-center"
+                className="flex items-center justify-center"
               >
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/packages/react-ui/src/app/components/ap-dashboard-sidebar-header.tsx
+++ b/packages/react-ui/src/app/components/ap-dashboard-sidebar-header.tsx
@@ -45,10 +45,7 @@ const ApDashboardSidebarHeader = ({
               >
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    {/**
-                     * sidebar header keep only website Name 
-                     */}
-                  <h1 className={`text-xl font-semibold ${theme === 'light'? 'text-gray-900' : ''}`}>{branding.websiteName}</h1>
+                    <h1 className={`text-xl font-semibold ${theme === 'light' ? 'text-gray-900' : ''}`}>{branding.websiteName}</h1>
                     {/* {showProjectSwitcher ? (
                       <img
                         src={branding.logos.logoIconUrl}


### PR DESCRIPTION
### What does this PR do?

- Just keep sidebar header only website name and remove logo in automation X
![image](https://github.com/user-attachments/assets/5c16ffb9-e5e6-4dcb-b865-c06c75feb1b9)


Fixes # (issue)
