### PR TITLE
fix: update analytics endpoints to calculate per project

### DIFF
--- a/packages/server/api/src/app/analytics/analytics-controller.ts
+++ b/packages/server/api/src/app/analytics/analytics-controller.ts
@@ -1,8 +1,10 @@
-import { AnalyticsResponseSchema, GetAnalyticsParams, OverviewResponseSchema } from '@activepieces/shared'
+import { AnalyticsResponseSchema, FlowStatus, GetAnalyticsParams, OverviewResponseSchema } from '@activepieces/shared'
 import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox'
-import { StatusCodes } from 'http-status-codes'
 import { analyticsService } from './analytics-service'
-
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import 'tslib'
+import jwt from 'jsonwebtoken'
 const ErrorResponse = {
     type: 'object',
     properties: {
@@ -36,62 +38,112 @@ const OverviewRequest = {
     },
 }
 
-export const analyticsController: FastifyPluginAsyncTypebox = async (app) => {
-    app.get('/flow-performance', AnalyticsRequest, async (request, reply) => {
-        try {
-            const { startDate, endDate } = request.query
+const _decodeJwt = (token: string): string => {
+    try {
+        // Decode the JWT without verifying the signature
+        const decoded = jwt.decode(token) as { projectId: string, platform: { id: string } }
 
-            // Convert timestamps to Date objects for comparison
-            const start = new Date(startDate)
-            const end = new Date(endDate)
-            const currentDateTime = new Date()
-
-            // Validate timestamps
-            if (isNaN(start.getTime()) || isNaN(end.getTime())) {
-                return await reply.status(StatusCodes.BAD_REQUEST).send({
-                    message: 'Invalid date format. Please provide valid dates.',
-                })
-            }
-
-            // Validate date range
-            if (start.getTime() >= end.getTime()) {
-                return await reply.status(StatusCodes.BAD_REQUEST).send({
-                    message: 'startDate must be less than endDate',
-                })
-            }
-
-            // Validate future dates
-            if (start.getTime() > currentDateTime.getTime() || end.getTime() > currentDateTime.getTime()) {
-                return await reply.status(StatusCodes.BAD_REQUEST).send({
-                    message: 'Dates cannot be in the future',
-                })
-            }
-
-            const analyticsData = await analyticsService.getAnalyticsData({
-                startDate,
-                endDate,
-            })
-
-            return await reply.send(analyticsData)
+        if (decoded && decoded.projectId) {
+            return decoded.projectId
         }
-        catch (error) {
-            app.log.error('Error fetching analytics data:', error)
-            return reply.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
-                message: 'An error occurred while fetching analytics data',
-            })
+        else {
+            throw new Error('Failed to decode JWT or missing projectId')
         }
-    })
+    }
+    catch (error) {
+        console.error('Error decoding JWT:', error)
+        throw new Error('Invalid JWT token')
+    }
+}
 
-    app.get('/overview', OverviewRequest, async (request, reply) => {
+
+
+export const analyticsController: FastifyPluginAsyncTypebox = async (app: FastifyInstance) => {
+    app.get('/workflow-performance',
+        AnalyticsRequest,
+        async (request: FastifyRequest, reply: FastifyReply) => {
+            try {
+                
+                const { startDate, endDate } = request.query as GetAnalyticsParams
+
+                // Extract the token from the Authorization header
+                const authHeader = request.headers.authorization
+
+                if (!authHeader || !authHeader.startsWith('Bearer ')) {
+                    return await reply.status(StatusCodes.UNAUTHORIZED).send({
+                        message: 'Authorization token is missing or invalid',
+                    })
+                }
+                const token = authHeader.split(' ')[1] // Extract the token part
+                
+                const projectId = _decodeJwt(token)
+                
+                // Convert timestamps to Date objects for comparison
+                const start = new Date(startDate)
+                const end = new Date(endDate)
+                const currentDateTime = new Date()
+
+                // Validate timestamps
+                if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+                    return await reply.status(StatusCodes.BAD_REQUEST).send({
+                        message: 'Invalid date format. Please provide valid dates.',
+                    })
+                }
+
+                // Validate date range
+                if (start.getTime() >= end.getTime()) {
+                    return await reply.status(StatusCodes.BAD_REQUEST).send({
+                        message: 'startDate must be less than endDate',
+                    })
+                }
+
+                // Validate future dates
+                if (start.getTime() > currentDateTime.getTime() || end.getTime() > currentDateTime.getTime()) {
+                    return await reply.status(StatusCodes.BAD_REQUEST).send({
+                        message: 'Dates cannot be in the future',
+                    })
+                }
+
+                const analyticsData = await analyticsService.getAnalyticsData({
+                    startDate,
+                    endDate,
+                    projectId,
+                })
+
+                return await reply.send(analyticsData)
+            }
+            catch (error) {
+                app.log.error('Error fetching analytics data:', error)
+                return reply.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+                    message: 'An error occurred while fetching analytics data',
+                })
+            }
+        },
+    ),
+    app.get('/overview', OverviewRequest, async (request: FastifyRequest, reply: FastifyReply) => {
         try {
-            const overviewData = await analyticsService.getWorkflowOverview()
+            // Extract the token from the Authorization header
+            const authHeader = request.headers.authorization
+
+            if (!authHeader || !authHeader.startsWith('Bearer ')) {
+                return await reply.status(StatusCodes.UNAUTHORIZED).send({
+                    message: 'Authorization token is missing or invalid',
+                })
+            }
+
+            const token = authHeader.split(' ')[1] // Extract the token part
+            const projectId = _decodeJwt(token)
+            const overviewData = await analyticsService.getWorkflowOverview(projectId)
             return await reply.send(overviewData)
         }
         catch (error) {
             app.log.error('Error fetching workflow overview:', error)
             return reply.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
-                message: 'An error occurred while fetching workflow overview',
+                message: 'An error occurred while fetching analytics data',
             })
         }
     })
 }
+
+
+   

--- a/packages/server/api/src/app/analytics/analytics-controller.ts
+++ b/packages/server/api/src/app/analytics/analytics-controller.ts
@@ -1,9 +1,8 @@
-import { AnalyticsResponseSchema, GetAnalyticsParams, OverviewResponseSchema } from '@activepieces/shared'
+import { AnalyticsResponse, GetAnalyticsParams, OverviewResponse } from '@activepieces/shared'
 import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox'
-import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { analyticsService } from './analytics-service'
-import 'tslib'
+
 const ErrorResponse = {
     type: 'object',
     properties: {
@@ -18,7 +17,7 @@ const AnalyticsRequest = {
         description: 'Get analytics data for flow-runs',
         querystring: GetAnalyticsParams,
         response: {
-            [StatusCodes.OK]: AnalyticsResponseSchema,
+            [StatusCodes.OK]: AnalyticsResponse,
             [StatusCodes.BAD_REQUEST]: ErrorResponse,
             [StatusCodes.INTERNAL_SERVER_ERROR]: ErrorResponse,
         },
@@ -31,67 +30,64 @@ const OverviewRequest = {
         tags: ['analytics'],
         description: 'Get workflow overview statistics',
         response: {
-            [StatusCodes.OK]: OverviewResponseSchema,
+            [StatusCodes.OK]: OverviewResponse,
             [StatusCodes.INTERNAL_SERVER_ERROR]: ErrorResponse,
         },
     },
 }
 
-export const analyticsController: FastifyPluginAsyncTypebox = async (app: FastifyInstance) => {
-    app.get('/workflow-performance',
-        AnalyticsRequest,
-        async (request: FastifyRequest, reply: FastifyReply) => {
-            try {
-                
-                const { startDate, endDate } = request.query as GetAnalyticsParams
-                const projectId: string = request.principal.projectId 
-
-                // Convert timestamps to Date objects for comparison
-                const start = new Date(startDate)
-                const end = new Date(endDate)
-                const currentDateTime = new Date()
-
-                // Validate timestamps
-                if (isNaN(start.getTime()) || isNaN(end.getTime())) {
-                    return await reply.status(StatusCodes.BAD_REQUEST).send({
-                        message: 'Invalid date format. Please provide valid dates.',
-                    })
-                }
-
-                // Validate date range
-                if (start.getTime() >= end.getTime()) {
-                    return await reply.status(StatusCodes.BAD_REQUEST).send({
-                        message: 'startDate must be less than endDate',
-                    })
-                }
-
-                // Validate future dates
-                if (start.getTime() > currentDateTime.getTime() || end.getTime() > currentDateTime.getTime()) {
-                    return await reply.status(StatusCodes.BAD_REQUEST).send({
-                        message: 'Dates cannot be in the future',
-                    })
-                }
-
-                const analyticsData = await analyticsService.getAnalyticsData({
-                    startDate,
-                    endDate,
-                    projectId,
-                })
-
-                return await reply.send(analyticsData)
-            }
-            catch (error) {
-                app.log.error('Error fetching analytics data:', error)
-                return reply.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
-                    message: 'An error occurred while fetching analytics data',
-                })
-            }
-        },
-    ),
-    app.get('/overview', OverviewRequest, async (request: FastifyRequest, reply: FastifyReply) => {
+export const analyticsController: FastifyPluginAsyncTypebox = async (app) => {
+    app.get('/flow-performance', AnalyticsRequest, async (request, reply) => {
         try {
-            const projectId: string = request.principal.projectId 
-            const overviewData = await analyticsService.getWorkflowOverview(projectId)
+            const projectId = request.principal.projectId
+            const { startDate, endDate } = request.query
+
+            // Convert timestamps to Date objects for comparison
+            const start = new Date(startDate)
+            const end = new Date(endDate)
+            const currentDateTime = new Date()
+
+            // Validate timestamps
+            if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+                return await reply.status(StatusCodes.BAD_REQUEST).send({
+                    message: 'Invalid date format. Please provide valid dates.',
+                })
+            }
+
+            // Validate date range
+            if (start.getTime() >= end.getTime()) {
+                return await reply.status(StatusCodes.BAD_REQUEST).send({
+                    message: 'startDate must be less than endDate',
+                })
+            }
+
+            // Validate future dates
+            if (start.getTime() > currentDateTime.getTime() || end.getTime() > currentDateTime.getTime()) {
+                return await reply.status(StatusCodes.BAD_REQUEST).send({
+                    message: 'Dates cannot be in the future',
+                })
+            }
+
+            const analyticsData = await analyticsService.getAnalyticsData({
+                startDate,
+                endDate,
+                projectId,
+            })
+
+            return await reply.send(analyticsData)
+        }
+        catch (error) {
+            app.log.error('Error fetching analytics data:', error)
+            return reply.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+                message: 'An error occurred while fetching analytics data',
+            })
+        }
+    })
+
+    app.get('/overview', OverviewRequest, async (request, reply) => {
+        try {
+            const projectId: string = request.principal.projectId
+            const overviewData = await analyticsService.getOverview(projectId)
             return await reply.send(overviewData)
         }
         catch (error) {
@@ -102,6 +98,3 @@ export const analyticsController: FastifyPluginAsyncTypebox = async (app: Fastif
         }
     })
 }
-
-
-   

--- a/packages/server/api/src/app/analytics/analytics-service.ts
+++ b/packages/server/api/src/app/analytics/analytics-service.ts
@@ -1,9 +1,10 @@
-import { AnalyticsResult, FlowRunStatus, FlowStatus, GetAnalyticsParams, GetOverviewParams, OverviewResult } from '@activepieces/shared'
+import { AnalyticsResult, FlowRunStatus, FlowStatus, OverviewResult } from '@activepieces/shared'
+import { Static, Type } from '@sinclair/typebox'
+import dayjs from 'dayjs'
 import { flowRepo } from '../flows/flow/flow.repo'
 import { flowRunRepo } from '../flows/flow-run/flow-run-service'
-import { Static, Type } from '@sinclair/typebox'
 import 'tslib'
-import dayjs from 'dayjs'
+
 
 export const GetAnalyticsDataParams = Type.Object({
     startDate: Type.String({ format: 'date-time' }),
@@ -12,7 +13,7 @@ export const GetAnalyticsDataParams = Type.Object({
 })
 export const analyticsService = {
     async getAnalyticsData(params: Static<typeof GetAnalyticsDataParams>): Promise<AnalyticsResult[]> {
-        const { startDate, endDate, projectId } = params;
+        const { startDate, endDate, projectId } = params
 
         const query = flowRunRepo()
             .createQueryBuilder('flowRun')
@@ -46,17 +47,17 @@ export const analyticsService = {
             .groupBy('DATE(flowRun.finishTime)')
             .orderBy('date', 'ASC')
 
-        const rawResults = await query.getRawMany();
+        const rawResults = await query.getRawMany()
         
         const results: AnalyticsResult[] = rawResults.map(result => ({
             date: result.date,
-            successfulFlowRuns: parseInt(result.successfulFlowRuns) || 0,
-            failedFlowRuns: parseInt(result.failedFlowRuns) || 0,
-            successfulFlowRunsDuration: parseInt(result.successfulFlowRunsDuration) || 0,
-            failedFlowRunsDuration: parseInt(result.failedFlowRunsDuration) || 0,
-        }));
+            successfulFlowRuns: result.successfulFlowRuns,
+            failedFlowRuns: result.failedFlowRuns,
+            successfulFlowRunsDuration: result.successfulFlowRunsDuration,
+            failedFlowRunsDuration: result.failedFlowRunsDuration,
+        }))
 
-        return results;
+        return results
     },
     async getWorkflowOverview(projectId: string): Promise<OverviewResult> {
         const { start, end } = {
@@ -83,9 +84,9 @@ export const analyticsService = {
 
         
         return {
-            workflowCount: parseInt(result.workflowCount) || 0,
-            activeWorkflowCount: parseInt(result.activeWorkflowCount) || 0,
-            flowRunCount: parseInt(result.flowRunCount) || 0,
+            workflowCount: result.workflowCount,
+            activeWorkflowCount: result.activeWorkflowCount,
+            flowRunCount: result.flowRunCount,
         }
     },
 }

--- a/packages/server/api/src/app/analytics/analytics-service.ts
+++ b/packages/server/api/src/app/analytics/analytics-service.ts
@@ -1,15 +1,19 @@
 import { AnalyticsResult, FlowRunStatus, FlowStatus, GetAnalyticsParams, GetOverviewParams, OverviewResult } from '@activepieces/shared'
 import { flowRepo } from '../flows/flow/flow.repo'
 import { flowRunRepo } from '../flows/flow-run/flow-run-service'
+import { Static, Type } from '@sinclair/typebox'
 import 'tslib'
 import dayjs from 'dayjs'
 
+export const GetAnalyticsDataParams = Type.Object({
+    startDate: Type.String({ format: 'date-time' }),
+    endDate: Type.String({ format: 'date-time' }),
+    projectId: Type.String(),
+})
 export const analyticsService = {
-    async getAnalyticsData({
-        startDate,
-        endDate,
-        projectId,
-    }: GetAnalyticsParams): Promise<AnalyticsResult[]> {
+    async getAnalyticsData(params: Static<typeof GetAnalyticsDataParams>): Promise<AnalyticsResult[]> {
+        const { startDate, endDate, projectId } = params;
+
         const query = flowRunRepo()
             .createQueryBuilder('flowRun')
             .select('DATE(flowRun.finishTime)', 'date')
@@ -42,7 +46,7 @@ export const analyticsService = {
             .groupBy('DATE(flowRun.finishTime)')
             .orderBy('date', 'ASC')
 
-        const rawResults = await query.getRawMany()
+        const rawResults = await query.getRawMany();
         
         const results: AnalyticsResult[] = rawResults.map(result => ({
             date: result.date,
@@ -50,9 +54,9 @@ export const analyticsService = {
             failedFlowRuns: parseInt(result.failedFlowRuns) || 0,
             successfulFlowRunsDuration: parseInt(result.successfulFlowRunsDuration) || 0,
             failedFlowRunsDuration: parseInt(result.failedFlowRunsDuration) || 0,
-        }))
+        }));
 
-        return results
+        return results;
     },
     async getWorkflowOverview(projectId: string): Promise<OverviewResult> {
         const { start, end } = {

--- a/packages/shared/src/lib/analytics/index.ts
+++ b/packages/shared/src/lib/analytics/index.ts
@@ -47,7 +47,6 @@ export type AnalyticsReportResponse = Static<typeof AnalyticsReportResponse>
 export const GetAnalyticsParams = Type.Object({
     startDate: Type.String({ format: 'date' }),
     endDate: Type.String({ format: 'date' }),
-    projectId: Type.String(),
 })
 export type GetAnalyticsParams = Static<typeof GetAnalyticsParams>
 

--- a/packages/shared/src/lib/analytics/index.ts
+++ b/packages/shared/src/lib/analytics/index.ts
@@ -47,6 +47,7 @@ export type AnalyticsReportResponse = Static<typeof AnalyticsReportResponse>
 export const GetAnalyticsParams = Type.Object({
     startDate: Type.String({ format: 'date' }),
     endDate: Type.String({ format: 'date' }),
+    projectId: Type.String(),
 })
 export type GetAnalyticsParams = Static<typeof GetAnalyticsParams>
 
@@ -69,6 +70,15 @@ export const AnalyticsResponseSchema = Type.Array(
 )
 export type AnalyticsResponse = Static<typeof AnalyticsResponseSchema>
 
+
+
+//For Overview API
+
+export const GetOverviewParams = Type.Object({
+    projectId: Type.String(),
+    platformId: Type.String(),
+})
+export type GetOverviewParams = Static<typeof GetOverviewParams>
 export type OverviewResult = {
     workflowCount: number
     activeWorkflowCount: number

--- a/packages/shared/src/lib/analytics/index.ts
+++ b/packages/shared/src/lib/analytics/index.ts
@@ -2,7 +2,7 @@ import { Static, Type } from '@sinclair/typebox'
 
 
 export const AnalyticsPieceReportItem = Type.Object({
-    name: Type.String(),        
+    name: Type.String(),
     displayName: Type.String(),
     logoUrl: Type.String(),
     usageCount: Type.Number(),
@@ -50,15 +50,7 @@ export const GetAnalyticsParams = Type.Object({
 })
 export type GetAnalyticsParams = Static<typeof GetAnalyticsParams>
 
-export type AnalyticsResult = {
-    date: string
-    successfulFlowRuns: number
-    failedFlowRuns: number
-    successfulFlowRunsDuration: number
-    failedFlowRunsDuration: number
-}
-
-export const AnalyticsResponseSchema = Type.Array(
+export const AnalyticsResponse = Type.Array(
     Type.Object({
         date: Type.String(),
         successfulFlowRuns: Type.Number(),
@@ -67,20 +59,11 @@ export const AnalyticsResponseSchema = Type.Array(
         failedFlowRunsDuration: Type.Number(),
     }),
 )
-export type AnalyticsResponse = Static<typeof AnalyticsResponseSchema>
+export type AnalyticsResponse = Static<typeof AnalyticsResponse>
 
-
-
-//For Overview API
-export type OverviewResult = {
-    workflowCount: number
-    activeWorkflowCount: number
-    flowRunCount: number
-}
-
-export const  OverviewResponseSchema = Type.Object({
+export const OverviewResponse = Type.Object({
     workflowCount: Type.Number(),
     activeWorkflowCount: Type.Number(),
     flowRunCount: Type.Number(),
 })
-export type OverviewResponse = Static<typeof OverviewResponseSchema>
+export type OverviewResponse = Static<typeof OverviewResponse>

--- a/packages/shared/src/lib/analytics/index.ts
+++ b/packages/shared/src/lib/analytics/index.ts
@@ -72,12 +72,6 @@ export type AnalyticsResponse = Static<typeof AnalyticsResponseSchema>
 
 
 //For Overview API
-
-export const GetOverviewParams = Type.Object({
-    projectId: Type.String(),
-    platformId: Type.String(),
-})
-export type GetOverviewParams = Static<typeof GetOverviewParams>
 export type OverviewResult = {
     workflowCount: number
     activeWorkflowCount: number


### PR DESCRIPTION
Add 'projectId' to the filter to ensure only the flows
created by current user.

Previously, the query returned all flows.