### PR TITLE
fix: display platform admin toggle if cloud platform

### DIFF
--- a/packages/react-ui/src/app/components/platform-admin-container.tsx
+++ b/packages/react-ui/src/app/components/platform-admin-container.tsx
@@ -28,13 +28,14 @@ export function PlatformAdminContainer({
   const [setupOpen, setSetupOpen] = useState(false);
   const [securityOpen, setSecurityOpen] = useState(false);
   const [infrastructureOpen, setInfrastructureOpen] = useState(false);
-  const { platform } = platformHooks.useCurrentPlatform();
+  // const { platform } = platformHooks.useCurrentPlatform();
   const { data: edition } = flagsHooks.useFlag<ApEdition>(ApFlagId.EDITION);
 
   const { data: showPlatformDemo } = flagsHooks.useFlag<boolean>(
     ApFlagId.SHOW_PLATFORM_DEMO,
   );
 
+  const isCloudPlatform = platformHooks.useIsCloudPlatform();
   const showPlatformAdminDashboard = useShowPlatformAdminDashboard();
   const isLocked = (locked: boolean) => locked || (showPlatformDemo ?? false);
   const items: SidebarItem[] = [
@@ -172,30 +173,36 @@ export function PlatformAdminContainer({
     //     },
     //   ],
     // },
-    // {
-    //   type: 'group',
-    //   label: t('Infrastructure'),
-    //   icon: Server,
-    //   defaultOpen: false,
-    //   open: infrastructureOpen,
-    //   setOpen: setInfrastructureOpen,
-    //   isActive: (pathname: string) => pathname.includes('/infrastructure'),
-    //   items: [
-    //     {
-    //       type: 'link',
-    //       to: '/platform/infrastructure/workers',
-    //       label: t('Workers'),
-    //       isSubItem: true,
-    //     },
-    //     {
-    //       type: 'link',
-    //       to: '/platform/infrastructure/health',
-    //       label: t('Health'),
-    //       isSubItem: true,
-    //     },
-    //   ],
-    // },
+    {
+      type: 'group',
+      label: t('Infrastructure'),
+      icon: Server,
+      defaultOpen: false,
+      open: infrastructureOpen,
+      setOpen: setInfrastructureOpen,
+      isActive: (pathname: string) => pathname.includes('/infrastructure'),
+      items: [
+        {
+          type: 'link',
+          to: '/platform/infrastructure/workers',
+          label: t('Workers'),
+          isSubItem: true,
+        },
+        {
+          type: 'link',
+          to: '/platform/infrastructure/health',
+          label: t('Health'),
+          isSubItem: true,
+        },
+      ],
+    },
   ];
+
+  // Only show Infrastructure group for cloud platform
+  if (!isCloudPlatform) {
+    items.pop();
+  }
+
   if (edition === ApEdition.CLOUD && !showPlatformDemo) {
     const setupGroup = items.find(
       (item) => item.type === 'group' && item.label === t('Setup'),

--- a/packages/react-ui/src/app/components/sidebar.tsx
+++ b/packages/react-ui/src/app/components/sidebar.tsx
@@ -172,6 +172,7 @@ export function SidebarComponent({
   removeBottomPadding = false,
 }: SidebarProps) {
   const { platform } = platformHooks.useCurrentPlatform();
+  const isCloudPlatform = platformHooks.useIsCloudPlatform();
   // const { data: showBilling } = flagsHooks.useFlag<boolean>(
   //   ApFlagId.SHOW_BILLING,
   // );
@@ -284,11 +285,13 @@ export function SidebarComponent({
                   <SidebarGroup>
                     <SidebarGroupLabel>{t('Misc')}</SidebarGroupLabel>
                     <SidebarMenu>
-                      {/* <SidebarMenuItem>
-                        <SidebarMenuButton asChild>
-                          <SidebarPlatformAdminButton />
-                        </SidebarMenuButton>
-                      </SidebarMenuItem> */}
+                      {isCloudPlatform && (
+                        <SidebarMenuItem>
+                          <SidebarMenuButton asChild>
+                            <SidebarPlatformAdminButton />
+                          </SidebarMenuButton>
+                        </SidebarMenuItem>
+                      )}
                       {!location.pathname.startsWith('/platform') && (
                         <SidebarMenuItem>
                           <SidebarMenuButton asChild>

--- a/packages/react-ui/src/hooks/platform-hooks.ts
+++ b/packages/react-ui/src/hooks/platform-hooks.ts
@@ -30,4 +30,13 @@ export const platformHooks = {
       },
     };
   },
+  useIsCloudPlatform: () => {
+    const currentPlatformId = authenticationSession.getPlatformId();
+    const query = useSuspenseQuery({
+      queryKey: ['is-cloud-platform', currentPlatformId],
+      queryFn: platformApi.isCloudPlatform,
+      staleTime: Infinity,
+    });
+    return query.data;
+  },
 };

--- a/packages/react-ui/src/lib/platforms-api.ts
+++ b/packages/react-ui/src/lib/platforms-api.ts
@@ -15,6 +15,14 @@ export const platformApi = {
     return api.get<PlatformWithoutSensitiveData>(`/v1/platforms/${platformId}`);
   },
 
+  isCloudPlatform() {
+    const platformId = authenticationSession.getPlatformId();
+    if (!platformId) {
+      return Promise.resolve(false);
+    }
+    return api.get<boolean>(`/v1/platforms/is-cloud-platform/${platformId}`);
+  },
+
   verifyLicenseKey(licenseKey: string) {
     const platformId = authenticationSession.getPlatformId();
     if (!platformId) {

--- a/packages/server/api/src/app/platform/platform.controller.ts
+++ b/packages/server/api/src/app/platform/platform.controller.ts
@@ -15,6 +15,7 @@ import { StatusCodes } from 'http-status-codes'
 // import { platformMustBeOwnedByCurrentUser } from '../ee/authentication/ee-authorization'
 // import { smtpEmailSender } from '../ee/helper/email/email-sender/smtp-email-sender'
 // import { licenseKeysService } from '../ee/license-keys/license-keys-service'
+import { flagService } from '../flags/flag.service'
 import { platformService } from './platform.service'
 
 export const platformController: FastifyPluginAsyncTypebox = async (app) => {
@@ -48,6 +49,11 @@ export const platformController: FastifyPluginAsyncTypebox = async (app) => {
         // platformWithoutSensitiveData.hasLicenseKey = licenseKey !== null
         return platformWithoutSensitiveData
     })
+
+    app.get('/is-cloud-platform/:id', IsCloudPlatformRequest, async (req) => {
+        const platformId = req.principal.platform.id
+        return flagService.isCloudPlatform(platformId)
+    })
 }
 
 const UpdatePlatformRequest = {
@@ -76,6 +82,24 @@ const GetPlatformRequest = {
         }),
         response: {
             [StatusCodes.OK]: PlatformWithoutSensitiveData,
+        },
+    },
+}
+
+const IsCloudPlatformRequest = {
+    config: {
+        allowedPrincipals: [PrincipalType.USER, PrincipalType.SERVICE],
+        scope: EndpointScope.PLATFORM,
+    },
+    schema: {
+        tags: ['platforms'],
+        security: [],
+        description: 'Check if on a cloud platform',
+        params: Type.Object({
+            id: ApId,
+        }),
+        response: {
+            [StatusCodes.OK]: Type.Boolean(),
         },
     },
 }


### PR DESCRIPTION
### What does this PR do?
- Add `is-cloud-platform` API to support checking the same from UI (without exposing the ID)
- Update UI to
  - Show the toggle button for admin dashboard (this will be eventually removed)
  - Show Infrastructure group in the admin dashboard if cloud platform (this will stay and the reason for this change)
- Wrapped the FE API in a react-suspense query for benefits
