### PR TITLE
fix: use token from search param first and use old token

### DIFF
--- a/packages/react-ui/src/features/authentication/components/auth-form-template.tsx
+++ b/packages/react-ui/src/features/authentication/components/auth-form-template.tsx
@@ -74,7 +74,7 @@ const AuthFormTemplate = React.memo(
     const [searchParams] = useSearchParams();
     const from = searchParams.get('from');
     const tokenFromUrl = searchParams.get('token');
-    const token = authenticationSession.getToken();
+    const token = tokenFromUrl ?? authenticationSession.getToken();
 
     // To redirect to PromptX login page
     const { data: loginUrl } = flagsHooks.useFlag<string>(ApFlagId.LOGIN_URL);


### PR DESCRIPTION
### What does this PR do?

- Use token from Search params first and if no token from search, will use existing local storage token.

Fixes # (issue)
