### PR TITLE
fix: hide language switcher in settings appereance

### DIFF
--- a/packages/react-ui/src/app/routes/settings/appearance/index.tsx
+++ b/packages/react-ui/src/app/routes/settings/appearance/index.tsx
@@ -87,8 +87,9 @@ export default function AppearancePage() {
             </RadioGroup>
           </div>
         </div>
-        <Separator />
-        <LanguageSwitcher></LanguageSwitcher>
+        {/* hide language switcher  */}
+        {/* <Separator />
+        <LanguageSwitcher></LanguageSwitcher> */}
       </div>
     </div>
   );


### PR DESCRIPTION
- Hide Language Switcher button in settings/appereance

![image](https://github.com/user-attachments/assets/2a875664-6251-4937-a07c-f0421a25fa2a)
