### PR TITLE
fix: remove appearance, theme toggle from project settings dropdown and remove mcp link from sidebar

### DIFF
--- a/packages/react-ui/src/app/components/dashboard-container.tsx
+++ b/packages/react-ui/src/app/components/dashboard-container.tsx
@@ -101,7 +101,7 @@ export function DashboardContainer({
     label: t('MCP'),
     icon: Server,
     showInEmbed: true,
-    hasPermission: checkAccess(Permission.READ_MCP),
+    hasPermission: false && checkAccess(Permission.READ_MCP),
     isSubItem: false,
   };
 

--- a/packages/react-ui/src/app/components/settings-dropdown-menu.tsx
+++ b/packages/react-ui/src/app/components/settings-dropdown-menu.tsx
@@ -55,6 +55,7 @@ const SettingsDropdownMenu = () => {
         '/settings/appearance',
       ),
       icon: <SunMoon className="h-4 w-4" />,
+      hasPermission: false,
     },
     {
       title: t('Team'),
@@ -106,7 +107,7 @@ const SettingsDropdownMenu = () => {
         </Tooltip>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-[180px] space-y-[2px]">
-        <ThemeToggle />
+        {/* <ThemeToggle /> */}
         {filteredLinkItems.map((item) => (
           <DropdownMenuItem key={item.title} className="p-0">
             <Link

--- a/packages/react-ui/src/app/routes/settings/appearance/index.tsx
+++ b/packages/react-ui/src/app/routes/settings/appearance/index.tsx
@@ -87,9 +87,8 @@ export default function AppearancePage() {
             </RadioGroup>
           </div>
         </div>
-        {/* hide language switcher  */}
-        {/* <Separator />
-        <LanguageSwitcher></LanguageSwitcher> */}
+        <Separator />
+        <LanguageSwitcher></LanguageSwitcher>
       </div>
     </div>
   );


### PR DESCRIPTION
### What does this PR do?
- Added back the language switcher to appearance page (as we removed the entire page from dropdown)
- Removed theme toggle and appearance sections from the project settings dropdown
- Removed MCP link from the sidebar as well
