### PR TITLE
fix: add max width for add field item

### DIFF
--- a/packages/react-ui/src/features/tables/components/new-field-popup.tsx
+++ b/packages/react-ui/src/features/tables/components/new-field-popup.tsx
@@ -124,7 +124,7 @@ export function NewFieldPopup({ children }: NewFieldDialogProps) {
             })}
             className="mx-2"
           >
-            <div className="max-h-[80vh]  overflow-y-auto space-y-4 px-1 ">
+            <div className="max-h-[450px]  overflow-y-auto space-y-4 px-1 ">
               <FormField
                 control={form.control}
                 name="name"


### PR DESCRIPTION
### What does this PR do?

- add max height to 450 for adding option items

![image](https://github.com/user-attachments/assets/992f8870-8811-4e0f-9716-640ba732a255)

